### PR TITLE
test: Update snapshots after new version of css-reader was released

### DIFF
--- a/test/__snapshots__/multi-client.test.js.snap
+++ b/test/__snapshots__/multi-client.test.js.snap
@@ -8,21 +8,27 @@ exports[`Client gets bundled css file from build server 1`] = `
 
 .b-title {
     color: red;
-}body {
+}
+
+body {
     margin: 0;
     padding: 0;
 }
 
 .c-title {
     color: green;
-}body {
+}
+
+body {
     margin: 0;
     padding: 0;
 }
 
 .a-title {
     color: blue;
-}"
+}
+
+"
 `;
 
 exports[`Client gets bundled js file from build server 1`] = `
@@ -60,8 +66,8 @@ module.exports = function sum(a, b) {
 
 exports[`Client requests bundling of a css feed on build server 1`] = `
 Object {
-  "file": "b4857973583b2f96fad4ecd5752f33aa93806ba3e451ff65115b1aba6fe36f36.css",
-  "uri": "http://127.0.0.1:7200/bundle/b4857973583b2f96fad4ecd5752f33aa93806ba3e451ff65115b1aba6fe36f36.css",
+  "file": "55960ccd31726d68f266bff255570763dbf3d98cf5c6dd8028f3f3d2430b5451.css",
+  "uri": "http://127.0.0.1:7200/bundle/55960ccd31726d68f266bff255570763dbf3d98cf5c6dd8028f3f3d2430b5451.css",
 }
 `;
 

--- a/test/__snapshots__/scenarios.test.js.snap
+++ b/test/__snapshots__/scenarios.test.js.snap
@@ -43,28 +43,36 @@ module.exports = function sum(a, b) {
 exports[`Layout and 3 podlets - run 1 - initial 2`] = `
 ".e-title {
     color: black;
-}body {
+}
+
+body {
     margin: 0;
     padding: 0;
 }
 
 .a-title {
     color: blue;
-}body {
+}
+
+body {
     margin: 0;
     padding: 0;
 }
 
 .b-title {
     color: red;
-}body {
+}
+
+body {
     margin: 0;
     padding: 0;
 }
 
 .c-title {
     color: green;
-}"
+}
+
+"
 `;
 
 exports[`Layout and 3 podlets - run 2 - identical to run 1 1`] = `
@@ -110,28 +118,36 @@ module.exports = function sum(a, b) {
 exports[`Layout and 3 podlets - run 2 - identical to run 1 2`] = `
 ".e-title {
     color: black;
-}body {
+}
+
+body {
     margin: 0;
     padding: 0;
 }
 
 .a-title {
     color: blue;
-}body {
+}
+
+body {
     margin: 0;
     padding: 0;
 }
 
 .b-title {
     color: red;
-}body {
+}
+
+body {
     margin: 0;
     padding: 0;
 }
 
 .c-title {
     color: green;
-}"
+}
+
+"
 `;
 
 exports[`Layout and 3 podlets - run 3 - swapped bundling order 1`] = `
@@ -177,26 +193,34 @@ module.exports = function sum(a, b) {
 exports[`Layout and 3 podlets - run 3 - swapped bundling order 2`] = `
 ".e-title {
     color: black;
-}body {
+}
+
+body {
     margin: 0;
     padding: 0;
 }
 
 .b-title {
     color: red;
-}body {
+}
+
+body {
     margin: 0;
     padding: 0;
 }
 
 .c-title {
     color: green;
-}body {
+}
+
+body {
     margin: 0;
     padding: 0;
 }
 
 .a-title {
     color: blue;
-}"
+}
+
+"
 `;

--- a/test/__snapshots__/single-client.test.js.snap
+++ b/test/__snapshots__/single-client.test.js.snap
@@ -102,7 +102,9 @@ input, select {
 h1 {
     color: #000000;
     size: 32px;
-}"
+}
+
+"
 `;
 
 exports[`Client gets bundled js file from build server 1`] = `
@@ -277,8 +279,8 @@ module.exports.hello = function hello() {
 
 exports[`Client requests bundling of a css feed on build server 1`] = `
 Object {
-  "file": "8b30de6afdb4474cfd5c5df052408dc6ee170d243861c3fa63d246440b5f472d.css",
-  "uri": "http://127.0.0.1:7100/bundle/8b30de6afdb4474cfd5c5df052408dc6ee170d243861c3fa63d246440b5f472d.css",
+  "file": "a4860db1f4c62bcf5f1726509673ace0070b5c83f21f3f8f93bba426441fc2c1.css",
+  "uri": "http://127.0.0.1:7100/bundle/a4860db1f4c62bcf5f1726509673ace0070b5c83f21f3f8f93bba426441fc2c1.css",
 }
 `;
 

--- a/test/__snapshots__/sinks.test.js.snap
+++ b/test/__snapshots__/sinks.test.js.snap
@@ -4,8 +4,8 @@ exports[`asset-pipe-sink-fs css bundle fetching 1`] = `Object {}`;
 
 exports[`asset-pipe-sink-fs css bundling 1`] = `
 Object {
-  "file": "8b30de6afdb4474cfd5c5df052408dc6ee170d243861c3fa63d246440b5f472d.css",
-  "uri": "/bundle/8b30de6afdb4474cfd5c5df052408dc6ee170d243861c3fa63d246440b5f472d.css",
+  "file": "a4860db1f4c62bcf5f1726509673ace0070b5c83f21f3f8f93bba426441fc2c1.css",
+  "uri": "/bundle/a4860db1f4c62bcf5f1726509673ace0070b5c83f21f3f8f93bba426441fc2c1.css",
 }
 `;
 
@@ -189,8 +189,8 @@ exports[`asset-pipe-sink-gcs css bundle fetching 1`] = `Object {}`;
 
 exports[`asset-pipe-sink-gcs css bundling 1`] = `
 Object {
-  "file": "8b30de6afdb4474cfd5c5df052408dc6ee170d243861c3fa63d246440b5f472d.css",
-  "uri": "/bundle/8b30de6afdb4474cfd5c5df052408dc6ee170d243861c3fa63d246440b5f472d.css",
+  "file": "a4860db1f4c62bcf5f1726509673ace0070b5c83f21f3f8f93bba426441fc2c1.css",
+  "uri": "/bundle/a4860db1f4c62bcf5f1726509673ace0070b5c83f21f3f8f93bba426441fc2c1.css",
 }
 `;
 


### PR DESCRIPTION
## Status
**READY**

## Description
A new version of https://github.com/asset-pipe/asset-pipe-css-reader was released which broke some of the snapshots. Updated snapshots to fix.

## Todos
- [x] Tests